### PR TITLE
chore: update flutter blue plus dependency

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   firebase_auth: ^4.7.3
   google_sign_in: ^6.1.4
   sign_in_with_apple: ^4.3.0
-  flutter_blue_plus: ^1.4.5
+  flutter_blue_plus: ^1.35.5
   fl_chart: ^0.68.0
   hive: ^2.2.3
   hive_flutter: ^1.1.0


### PR DESCRIPTION
## Summary
- use latest `flutter_blue_plus` library

## Testing
- `dart pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a66a90d8908327b0e6430a33bea3ed